### PR TITLE
Fill in the number of concepts learned

### DIFF
--- a/src/pages/tutorials/json-parsing-rust-1.mdx
+++ b/src/pages/tutorials/json-parsing-rust-1.mdx
@@ -1580,7 +1580,7 @@ pub enum TokenizeError {
 
 We have now completed _an_ implementation of tokenizing for JSON tokens, ideally as a practical example to teach Rust syntax, semantics, and language features.
 
-Throughout this tutorial, you have learned \_\_ new concepts! (plus or minus a few). That's really good! One thing that's neat about Rust is that there are a few broad themes that connect everything (ownership, borrowing) but besides that each feature is generally self-contained and can be taught on its own (if you want to sound fancy, you'd say that the features are mostly _orthogonal_ to each other).
+Throughout this tutorial, you have learned 17 new concepts! (plus or minus a few). That's really good! One thing that's neat about Rust is that there are a few broad themes that connect everything (ownership, borrowing) but besides that each feature is generally self-contained and can be taught on its own (if you want to sound fancy, you'd say that the features are mostly _orthogonal_ to each other).
 
 The [next and last article](./json-parsing-rust-2) in this series will contain much more code than this article, but fewer new concepts because most were learned already.
 


### PR DESCRIPTION
This seems to have been an oversight. The MDX source has seventeen occurences of `<NewConcept`.